### PR TITLE
Fixed ZMQ includes for realtime visualization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};
                     -gencode=arch=compute_50,code=sm_50
                     -gencode=arch=compute_52,code=sm_52
                     -gencode=arch=compute_60,code=sm_60
-		            -gencode=arch=compute_61,code=sm_61
+                    -gencode=arch=compute_61,code=sm_61
                     -gencode=arch=compute_70,code=sm_70
                     -std=c++11
                     -Xcompiler '-O3'
@@ -200,6 +200,7 @@ if(BUILD_PYTHON)
             ${BLAS_LIB}
             glog
             -Wl,--allow-multiple-definition
+            -Wl,-shared
         )
     else()
         target_link_libraries(tsnecuda

--- a/src/include/fit_tsne.h
+++ b/src/include/fit_tsne.h
@@ -26,6 +26,10 @@
 #include "include/kernels/nbodyfft.h"
 #include "include/kernels/rep_forces.h"
 
+#ifndef NO_ZMQ
+    #include <zmq.hpp>
+#endif
+
 namespace tsnecuda {
 void RunTsne(tsnecuda::Options &opt, tsnecuda::GpuOptions &gpu_opt);
 }


### PR DESCRIPTION
Includes a minor fix where the ZMQ header was not included, as well as updates a minor issue with shared libraries in the CMakeLists. Fixes the WITH_ZMQ argument for CUDA 10.