### PR TITLE
Streamline build for modern GPUs (A100/H100/B200); drop gflags/gtest/ZMQ/CLI; v4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,19 +31,19 @@ ADD_DEFINITIONS(-DVERSION_PATCH=${CMAKE_PROJECT_VERSION_PATCH})
 # CXX Configuration
 #-------------------------------------------------------------------------------
 set(OPT_FLAGS
-    -std=c++14
+    -std=c++17
     -fopenmp
-    -mpopcnt
-    -msse4
     -fPIC
-    -m64
     -Wno-sign-compare
-    -g
     -O3
     -Wall
     -Wextra
     -DFINTEGER=int
 )
+# x86-only tuning flags; omitted on aarch64 (e.g. Grace/GB200) and other ISAs.
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64|i[3-6]86)$")
+    list(APPEND OPT_FLAGS -m64 -mpopcnt -msse4)
+endif()
 string(REPLACE ";" " " CXX_FLAGS_STR "${CMAKE_CXX_FLAGS} ${OPT_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CXX_FLAGS_STR}")
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
@@ -54,87 +54,102 @@ set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 #-------------------------------------------------------------------------------
 find_package(CUDAToolkit REQUIRED)
 if(NOT DEFINED CMAKE_CUDA_STANDARD)
-    set(CMAKE_CUDA_STANDARD 14)
+    set(CMAKE_CUDA_STANDARD 17)
     set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 endif()
 
-if(CUDAToolkit_VERSION_MAJOR EQUAL "10")
-    set(CUDA_ARCH
-        -gencode=arch=compute_30,code=sm_30
-        -gencode=arch=compute_35,code=sm_35
-        -gencode=arch=compute_37,code=sm_37
-        -gencode=arch=compute_50,code=sm_50
-        -gencode=arch=compute_52,code=sm_52
-        -gencode=arch=compute_60,code=sm_60
-        -gencode=arch=compute_61,code=sm_61
-        -gencode=arch=compute_70,code=sm_70
-        -gencode=arch=compute_75,code=sm_75
-    )
-elseif(CUDAToolkit_VERSION_MAJOR EQUAL "11" AND CUDAToolkit_VERSION_MINOR LESS "1")
-    set(CUDA_ARCH
-        -gencode=arch=compute_35,code=sm_35
-        -gencode=arch=compute_37,code=sm_37
-        -gencode=arch=compute_50,code=sm_50
-        -gencode=arch=compute_52,code=sm_52
-        -gencode=arch=compute_60,code=sm_60
-        -gencode=arch=compute_61,code=sm_61
-        -gencode=arch=compute_70,code=sm_70
-        -gencode=arch=compute_75,code=sm_75
-        -gencode=arch=compute_80,code=sm_80
-    )
-elseif(CUDAToolkit_VERSION_MAJOR EQUAL "11")
-    set(CUDA_ARCH
-        -gencode=arch=compute_35,code=sm_35
-        -gencode=arch=compute_37,code=sm_37
-        -gencode=arch=compute_50,code=sm_50
-        -gencode=arch=compute_52,code=sm_52
-        -gencode=arch=compute_60,code=sm_60
-        -gencode=arch=compute_61,code=sm_61
-        -gencode=arch=compute_70,code=sm_70
-        -gencode=arch=compute_75,code=sm_75
-        -gencode=arch=compute_80,code=sm_80
-        -gencode=arch=compute_86,code=sm_86
-    )
-elseif(CUDAToolkit_VERSION_MAJOR EQUAL "12")
-    set(CUDA_ARCH
-        -gencode=arch=compute_60,code=sm_60
-        -gencode=arch=compute_61,code=sm_61
-        -gencode=arch=compute_70,code=sm_70
-        -gencode=arch=compute_75,code=sm_75
-        -gencode=arch=compute_80,code=sm_80
-        -gencode=arch=compute_86,code=sm_86
-        -gencode=arch=compute_87,code=sm_87
-        -gencode=arch=compute_89,code=sm_89
-        -gencode=arch=compute_90,code=sm_90
-    )
+# Architecture selection
+# -----------------------------------------------------------------------------
+# The kernels use no architecture-specific intrinsics (no warp shuffle/vote,
+# no cooperative groups, no tensor-core / wgmma), so a plain `sm_XX` cubin per
+# target produces optimal SASS, and a single trailing PTX entry provides JIT
+# forward-compatibility for GPUs newer than the toolkit. The `sm_XXa`
+# accelerated variants are therefore intentionally omitted.
+#
+# If a packager or user supplies CMAKE_CUDA_ARCHITECTURES (conda-forge passes it
+# through CMAKE_ARGS), honor it and let CMake emit the -gencode flags; we only
+# add the non-arch optimization flags. Otherwise pick an optimal ladder for the
+# detected toolkit, covering current datacenter GPUs:
+#   A100 = sm_80, H100/H200 = sm_90, B200 = sm_100, GB202/RTX50 = sm_120.
+if(DEFINED CMAKE_CUDA_ARCHITECTURES
+   AND NOT CMAKE_CUDA_ARCHITECTURES STREQUAL ""
+   AND NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "OFF")
+    message(STATUS "tsnecuda: honoring CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
+    set(CUDA_ARCH "")
 else()
-    set(CUDA_ARCH
-        -gencode=arch=compute_30,code=sm_30
-        -gencode=arch=compute_35,code=sm_35
-        -gencode=arch=compute_37,code=sm_37
-        -gencode=arch=compute_50,code=sm_50
-        -gencode=arch=compute_52,code=sm_52
-        -gencode=arch=compute_60,code=sm_60
-        -gencode=arch=compute_61,code=sm_61
+    # Disable CMake's own arch handling so it does not add conflicting -gencode.
+    set(CMAKE_CUDA_ARCHITECTURES OFF)
+    if(CUDAToolkit_VERSION_MAJOR EQUAL "13")
+        # CUDA 13 removed Maxwell/Pascal/Volta; minimum supported arch is Turing.
+        set(CUDA_ARCH
+            -gencode=arch=compute_75,code=sm_75
+            -gencode=arch=compute_80,code=sm_80
+            -gencode=arch=compute_86,code=sm_86
+            -gencode=arch=compute_89,code=sm_89
+            -gencode=arch=compute_90,code=sm_90
+            -gencode=arch=compute_100,code=sm_100
+            -gencode=arch=compute_120,code=sm_120
+            -gencode=arch=compute_120,code=compute_120
         )
+    elseif(CUDAToolkit_VERSION_MAJOR EQUAL "12")
+        set(CUDA_ARCH
+            -gencode=arch=compute_70,code=sm_70
+            -gencode=arch=compute_75,code=sm_75
+            -gencode=arch=compute_80,code=sm_80
+            -gencode=arch=compute_86,code=sm_86
+            -gencode=arch=compute_89,code=sm_89
+            -gencode=arch=compute_90,code=sm_90
+        )
+        # Blackwell (sm_100 / sm_120) requires CUDA >= 12.8.
+        if(CUDAToolkit_VERSION_MINOR GREATER_EQUAL "8")
+            list(APPEND CUDA_ARCH
+                -gencode=arch=compute_100,code=sm_100
+                -gencode=arch=compute_120,code=sm_120
+                -gencode=arch=compute_120,code=compute_120
+            )
+        else()
+            list(APPEND CUDA_ARCH -gencode=arch=compute_90,code=compute_90)
+        endif()
+    elseif(CUDAToolkit_VERSION_MAJOR EQUAL "11")
+        set(CUDA_ARCH
+            -gencode=arch=compute_52,code=sm_52
+            -gencode=arch=compute_60,code=sm_60
+            -gencode=arch=compute_61,code=sm_61
+            -gencode=arch=compute_70,code=sm_70
+            -gencode=arch=compute_75,code=sm_75
+            -gencode=arch=compute_80,code=sm_80
+        )
+        # sm_86 available on CUDA >= 11.1; sm_90 only on 11.8+.
+        if(CUDAToolkit_VERSION_MINOR GREATER_EQUAL "1")
+            list(APPEND CUDA_ARCH -gencode=arch=compute_86,code=sm_86)
+        endif()
+        list(APPEND CUDA_ARCH -gencode=arch=compute_80,code=compute_80)
+    else()
+        # Unknown/older toolkit: safe modern default with PTX fallback.
+        set(CUDA_ARCH
+            -gencode=arch=compute_70,code=sm_70
+            -gencode=arch=compute_75,code=sm_75
+            -gencode=arch=compute_80,code=sm_80
+            -gencode=arch=compute_80,code=compute_80
+        )
+    endif()
 endif()
 
 
 set(CUDA_OPTS
     -O3
-    -g
     -Xptxas '-dlcm=cg'
     -Xcompiler '-O3'
     -Xcompiler '-fPIC'
     -Xcompiler '-fopenmp'
-    -Xcompiler '-msse4'
-    -Xcompiler '-m64'
-    -Xcompiler '-mpopcnt'
-    -Xcompiler '-g'
     -Xlinker 'muldefs'
 )
+# x86-only host tuning flags for nvcc's host compiler; omitted on other ISAs.
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64|i[3-6]86)$")
+    list(APPEND CUDA_OPTS -Xcompiler '-msse4' -Xcompiler '-m64' -Xcompiler '-mpopcnt')
+endif()
 string (REPLACE ";" " " NVCC_FLAGS_STR "${CUDA_ARCH} ${CUDA_OPTS}")
-set(CMAKE_CUDA_FLAGS "${NVCC_FLAGS_STR}")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${NVCC_FLAGS_STR}")
 # list(APPEND CUDA_NVCC_FLAGS "--compiler-options -fPIC")
 #-------------------------------------------------------------------------------
 
@@ -143,22 +158,11 @@ set(CMAKE_CUDA_FLAGS "${NVCC_FLAGS_STR}")
 find_package(OpenMP REQUIRED)
 #-------------------------------------------------------------------------------
 
-# GTEST Configuration
+# Interactive-visualization (ZMQ) support is intentionally disabled: the ZMQ
+# publisher path in fit_tsne is compiled out via -DNO_ZMQ, dropping the zeromq /
+# cppzmq build and runtime dependency for a leaner, more portable package.
 #-------------------------------------------------------------------------------
-find_package(gflags REQUIRED)
-# find_package(GLog REQUIRED)
-find_package(GTest REQUIRED)
-#-------------------------------------------------------------------------------
-
-# ZMQ Configuration
-#-------------------------------------------------------------------------------
-find_package(ZMQ)
-if(NOT ${ZMQ_FOUND})
-    ADD_DEFINITIONS(-DNO_ZMQ)
-    set(ZMQ_INCLUDE_DIR "")
-    set(ZMQ_LIBRARIES "")
-    message("-- Not building with ZMQ. Interactive visualization disabled. To build with ZMQ use -DWITH_ZMQ=ON")
-endif()
+ADD_DEFINITIONS(-DNO_ZMQ)
 #-------------------------------------------------------------------------------
 
 # FAISS Configuration
@@ -176,8 +180,6 @@ include_directories(
     src/include
     ${CUDA_INCLUDE_DIRS}
     third_party/
-    third_party/cxxopts/include/
-    ${ZMQ_INCLUDE_DIR}
 )
 link_directories(
     ${CUDA_LIBRARIES}
@@ -223,8 +225,6 @@ set(PYTHON_SOURCES
 add_library(tsnecuda SHARED ${SOURCES})
 # set_property(TARGET tsnecuda PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 target_link_libraries(tsnecuda PRIVATE
-    gflags
-    gtest
     CUDA::cudart
     CUDA::cublas
     # CUDA::cublasLt
@@ -234,7 +234,6 @@ target_link_libraries(tsnecuda PRIVATE
     OpenMP::OpenMP_CXX
     pthread
     -Wl,--allow-multiple-definition
-    ${ZMQ_LIBRARIES}
     ${FAISS_LIBRARIES}
 )
 
@@ -253,10 +252,9 @@ endif()
 #-------------------------------------------------------------------------------
 
 #-------------------------------------------------------------------------------
-# Main executable
+# The standalone C++ CLI (src/exe/main.cu, which pulls in the cxxopts submodule)
+# is intentionally not built: the Python module is the supported entry point.
 #-------------------------------------------------------------------------------
-add_executable(tsne src/exe/main.cu)
-target_link_libraries(tsne tsnecuda)
 
 #-------------------------------------------------------------------------------
 # Python library copy and build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required (VERSION 3.20)
 project(tsnecuda)
-set (CMAKE_PROJECT_VERSION 3)
-set (CMAKE_PROJECT_VERSION_MAJOR 3)
+set (CMAKE_PROJECT_VERSION 4)
+set (CMAKE_PROJECT_VERSION_MAJOR 4)
 set (CMAKE_PROJECT_VERSION_MINOR 0)
-set (CMAKE_PROJECT_VERSION_PATCH 2)
+set (CMAKE_PROJECT_VERSION_PATCH 0)
 set (CMAKE_PROJECT_VERSION_PATH 0)
 set (CMAKE_SKIP_RULE_DEPENDENCY TRUE)
 set (CMAKE_EXPORT_COMPILE_COMMANDS 1)
@@ -237,18 +237,10 @@ target_link_libraries(tsnecuda PRIVATE
     ${FAISS_LIBRARIES}
 )
 
-# BLAS configuration
-#-------------------------------------------------------------------------------
-find_package(MKL)
-if(MKL_FOUND)
-  target_link_libraries(tsnecuda PRIVATE ${MKL_LIBRARIES})
-else()
-  find_package(BLAS REQUIRED)
-  target_link_libraries(tsnecuda PRIVATE ${BLAS_LIBRARIES})
-
-  find_package(LAPACK REQUIRED)
-  target_link_libraries(tsnecuda PRIVATE ${LAPACK_LIBRARIES})
-endif()
+# No CPU BLAS/LAPACK is linked: the library's only GEMM is GPU cuBLAS
+# (cublasSgemm), and FAISS carries its own BLAS transitively. Dropping the
+# find_package(BLAS/LAPACK/MKL) removes a vestigial dependency and, on the
+# conda-forge side, the libblas/liblapack pin (incl. the *netlib pin) entirely.
 #-------------------------------------------------------------------------------
 
 #-------------------------------------------------------------------------------

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,19 +39,18 @@ pip3 install tsnecuda==3.0.1+cu100 -f https://tsnecuda.isx.ai/tsnecuda_stable.ht
 
 A number of requirements are necessary for building our code from source.
 
-- CUDA: You will need a working version of the CUDA toolkit which can be obtained from here. Our code has been tested compiling with CUDA versions 9.0, 9.1, 9.2, 10.0, 10.1, 10.2, 11.0 and 11.2. Other versions - may not be supported.
+- CUDA: You will need a working version of the CUDA toolkit which can be obtained from here. Our code has been tested compiling with CUDA versions 11.x, 12.x, and 13.x. The build targets modern datacenter GPUs out of the box (A100, H100/H200, B200) and honors an externally supplied `-DCMAKE_CUDA_ARCHITECTURES=...`. Other versions may not be supported.
 - CMAKE: Version >= 3.20.0 which can be obtained by running sudo apt install cmake on ubuntu/debian systems.
 - MKL/OpenBLAS: If you're using MKL, install it using the intel provided installation scripts. If you're using OpenBLAS install it using sudo apt install libopenblas-dev on ubuntu/debian systems.
 - GCC/llvm-clang: This is likely already installed on your system. If not, on ubuntu you can run sudo apt install build-essential to get a version.
 - OpenMP: On ubuntu this is likely already installed with your version of GCC. For other distributions, be sure your compiler has OpenMP support.
-- Python (for Python bindings) >= 3.6: Python is not required, however to build the python bindings you must install Python.
-- Gflags >= 2.2: On ubuntu, you can install with `sudo apt install lilbgflags-dev`
-- Gtest >= 1.10: On ubuntu, you can install with `sudo apt install libgtest-dev`
-- FAISS >= 1.6.5: This can be installed by following the instructions (https://github.com/facebookresearch/faiss/blob/v1.6.5/INSTALL.md)[here]
+- Python (for Python bindings) >= 3.10: Python is not required, however to build the python bindings you must install Python. The python module is the supported entry point.
+- FAISS (GPU) >= 1.7: This can be installed from conda-forge with `conda install -c conda-forge libfaiss` (recommended), or built from source per the FAISS instructions.
 
 Optional:
   - Doxygen: To build the documentation, a working version of doxygen is required (which can be obtained using sudo apt install doxygen on debian/ubuntu systems).
-  - ZMQ: Necessary for building the interactive visualization. On ubuntu you can obtain ZMQ by using sudo apt install libzmq-dev.
+
+The standalone C++ CLI and the ZMQ-based interactive visualization are no longer built (the `gflags`, `gtest`, `cxxopts`, and `zmq` dependencies have been dropped) to keep the build lean and portable; use the Python module instead.
 
 
 First, clone the repository, and change into the cloned directory using:

--- a/cmake/benchmarks/tune_kernels.py
+++ b/cmake/benchmarks/tune_kernels.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Kernel launch-parameter tuning harness for tsne-cuda.
+
+The FFT-interpolation kernels expose their block sizes through GpuOptions, and
+those can be overridden at runtime via environment variables (see
+src/include/options.h):
+
+    TSNE_FFT_THREADS     nbodyfft interpolation/copy kernels   (default 128)
+    TSNE_ATTR_THREADS    attractive-forces (Pij x Qij) kernel  (default 1024)
+    TSNE_REP_THREADS     repulsive-forces / charges kernel     (default 1024)
+    TSNE_INTEG_THREADS   integration (apply-forces) kernel     (default 1024)
+    TSNE_INTEG_FACTOR    integration blocks-per-SM factor      (default 1)
+
+This script sweeps each parameter independently (holding the others at their
+default), running each configuration in a fresh subprocess so GPU state never
+leaks between runs, and parses the per-phase timers that fit_tsne prints under
+verbose=1. It reports, per kernel, the block size that minimises that kernel's
+phase time on the current device.
+
+Usage:
+    PYTHONPATH=<build>/python python tune_kernels.py [--data mnist.npz]
+        [--n 60000] [--iters 500] [--repeats 3]
+
+With no --data it uses reproducible gaussian-blob synthetic data.
+"""
+import argparse
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+import time
+
+# phase timer name (in fit_tsne output) that each env var most directly drives
+PHASE_FOR = {
+    "TSNE_FFT_THREADS": "_time_nbodyfft",
+    "TSNE_ATTR_THREADS": "_time_attr",
+    "TSNE_REP_THREADS": "_time_norm",
+    "TSNE_INTEG_THREADS": "_time_apply_forces",
+    "TSNE_INTEG_FACTOR": "_time_apply_forces",
+}
+GRID = {
+    "TSNE_FFT_THREADS": [32, 64, 128, 256, 512, 1024],
+    "TSNE_ATTR_THREADS": [64, 128, 256, 512, 1024],
+    "TSNE_REP_THREADS": [128, 256, 512, 1024],
+    "TSNE_INTEG_THREADS": [256, 512, 1024],
+    # threads-per-block is hardware-capped at 1024; the integration factor is a
+    # grid multiplier (grid = sm_count * factor) and can scale much higher, so we
+    # sweep it well past the SM count to find where extra blocks stop helping.
+    "TSNE_INTEG_FACTOR": [1, 2, 4, 8, 16, 32, 64, 128],
+}
+TIMER_RE = re.compile(r"^(_time_\w+|total_time):\s*([0-9.]+)s")
+
+
+def load_data(path, n):
+    import numpy as np
+    if path and os.path.exists(path):
+        d = np.load(path)
+        key = "x_train" if "x_train" in d else list(d.keys())[0]
+        X = d[key].reshape(d[key].shape[0], -1).astype(np.float32)
+        return X[:n]
+    rng = np.random.default_rng(0)
+    # 10 well-separated blobs in 50-D, like a clustered real dataset
+    per = n // 10
+    parts = [rng.standard_normal((per, 50)).astype(np.float32) + 12.0 * i for i in range(10)]
+    return np.vstack(parts)[:n]
+
+
+def run_worker(args):
+    """Single fit; prints fit_tsne's verbose timers + a BENCH_WALL line."""
+    import numpy as np
+    from tsnecuda import TSNE
+    X = load_data(args.data, args.n)
+    t0 = time.time()
+    TSNE(n_iter=args.iters, verbose=1, num_neighbors=64).fit_transform(X)
+    print("BENCH_WALL %.4f" % (time.time() - t0))
+
+
+def parse_timers(text):
+    out = {}
+    for line in text.splitlines():
+        m = TIMER_RE.match(line.strip())
+        if m:
+            out[m.group(1)] = float(m.group(2))
+        if line.startswith("BENCH_WALL"):
+            out["wall"] = float(line.split()[1])
+    return out
+
+
+def measure(env_overrides, args):
+    """Run repeats+1 times; drop the first (warmup) and return per-run timer dicts."""
+    env = dict(os.environ)
+    env.update({k: str(v) for k, v in env_overrides.items()})
+    samples = []
+    for i in range(args.repeats + 1):
+        r = subprocess.run([sys.executable, os.path.abspath(__file__), "--worker",
+                            "--data", args.data or "", "--n", str(args.n),
+                            "--iters", str(args.iters)],
+                           env=env, capture_output=True, text=True)
+        if r.returncode != 0:
+            sys.stderr.write(r.stderr[-2000:])
+            raise RuntimeError("worker failed for %s" % env_overrides)
+        if i == 0:
+            continue  # warmup
+        samples.append(parse_timers(r.stdout))
+    return samples
+
+
+def agg(samples, key):
+    xs = [s.get(key, float("nan")) for s in samples]
+    xs = [x for x in xs if x == x]  # drop NaN
+    mean = statistics.mean(xs) if xs else float("nan")
+    std = statistics.pstdev(xs) if len(xs) > 1 else 0.0
+    return mean, std
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--worker", action="store_true")
+    ap.add_argument("--data", default="")
+    ap.add_argument("--n", type=int, default=60000)
+    ap.add_argument("--iters", type=int, default=500)
+    ap.add_argument("--repeats", type=int, default=3)
+    ap.add_argument("--only", default="", help="comma list of env vars to sweep")
+    args = ap.parse_args()
+
+    if args.worker:
+        return run_worker(args)
+
+    params = [p for p in GRID if not args.only or p in args.only.split(",")]
+    print("device sweep: n=%d iters=%d repeats=%d data=%s\n"
+          % (args.n, args.iters, args.repeats, args.data or "synthetic"))
+    recommended = {}
+    for p in params:
+        phase = PHASE_FOR[p]
+        print("== %-18s (optimising %s; mean+-std over %d runs) =="
+              % (p, phase, args.repeats))
+        best_val, best_mean = None, float("inf")
+        for v in GRID[p]:
+            samples = measure({p: v}, args)
+            m_phase, s_phase = agg(samples, phase)
+            m_wall, s_wall = agg(samples, "wall")
+            print("   %-6s  %s=%7.3f+-%.3fs   wall=%7.3f+-%.3fs"
+                  % (v, phase, m_phase, s_phase, m_wall, s_wall))
+            if m_phase < best_mean:
+                best_mean, best_val = m_phase, v
+        recommended[p] = best_val
+        print("   -> best %s = %s (%s mean=%.3fs)\n" % (p, best_val, phase, best_mean))
+    print("RECOMMENDED:", json.dumps(recommended))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fit_tsne.cu
+++ b/src/fit_tsne.cu
@@ -418,7 +418,7 @@ void tsnecuda::RunTsne(tsnecuda::Options &opt,
 
         // Prepare the terms that we'll use to compute the sum i.e. the repulsive forces
         START_IL_TIMER();
-        tsnecuda::ComputeChargesQij(chargesQij_device, points_device, num_points, n_terms);
+        tsnecuda::ComputeChargesQij(gpu_opt, chargesQij_device, points_device, num_points, n_terms);
         END_IL_TIMER(_time_compute_charges);
 
         // Compute Minimax elements
@@ -441,6 +441,7 @@ void tsnecuda::RunTsne(tsnecuda::Options &opt,
         START_IL_TIMER();
 
         tsnecuda::NbodyFFT2D(
+            gpu_opt,
             plan_dft, plan_idft,
             N, n_terms, n_boxes_per_dim, n_interpolation_points,
             fft_kernel_tilde_device, n_total_boxes,
@@ -460,7 +461,7 @@ void tsnecuda::RunTsne(tsnecuda::Options &opt,
         // TODO: See: https://stackoverflow.com/questions/24368197/getting-cuda-thrust-to-use-a-cuda-stream-of-your-choice
         // Make the negative term, or F_rep in the equation 3 of the paper
         normalization = tsnecuda::ComputeRepulsiveForces(
-            repulsive_forces_device, normalization_vec_device, points_device,
+            gpu_opt, repulsive_forces_device, normalization_vec_device, points_device,
             potentialsQij_device, num_points, n_terms);
 
         END_IL_TIMER(_time_norm);

--- a/src/fit_tsne.cu
+++ b/src/fit_tsne.cu
@@ -405,9 +405,13 @@ void tsnecuda::RunTsne(tsnecuda::Options &opt,
         START_IL_TIMER();
         // TODO: We might be able to write a kernel which does this more efficiently. It probably doesn't require much
         // TODO: but it could be done.
-        float fill_value = 0;
-        thrust::fill(w_coefficients_device.begin(), w_coefficients_device.end(), fill_value);
-        thrust::fill(potentialsQij_device.begin(), potentialsQij_device.end(), fill_value);
+        // Zero the FFT accumulation buffers. cudaMemsetAsync is used instead of
+        // thrust::fill so this does not force a host<->device synchronization
+        // every iteration (the buffers are consumed later on the same stream).
+        cudaMemsetAsync(thrust::raw_pointer_cast(w_coefficients_device.data()), 0,
+                        w_coefficients_device.size() * sizeof(float));
+        cudaMemsetAsync(thrust::raw_pointer_cast(potentialsQij_device.data()), 0,
+                        potentialsQij_device.size() * sizeof(float));
         // Setup learning rate schedule
         if (step == opt.force_magnify_iters)
         {
@@ -510,11 +514,22 @@ void tsnecuda::RunTsne(tsnecuda::Options &opt,
                               num_points,
                               num_blocks);
 
-        // Compute the gradient norm
-        float grad_norm = tsnecuda::util::L2NormDeviceVector(old_forces_device);
-        thrust::fill(attractive_forces_device.begin(), attractive_forces_device.end(), 0.0f);
+        // The gradient-norm reduce is a host-synchronizing transform_reduce, so
+        // only compute it when it is actually used: when a positive
+        // min_gradient_norm early-stop is configured, or when we are about to
+        // print it. min_gradient_norm defaults to 0, so by default (and with
+        // verbose off) this expensive per-iteration sync is skipped entirely.
+        const bool need_grad_norm =
+            (opt.min_gradient_norm > 0.0f) ||
+            (opt.verbosity >= 1 && step % opt.print_interval == 0);
+        float grad_norm = 0.0f;
+        if (need_grad_norm)
+            grad_norm = tsnecuda::util::L2NormDeviceVector(old_forces_device);
 
-        if (grad_norm < opt.min_gradient_norm)
+        cudaMemsetAsync(thrust::raw_pointer_cast(attractive_forces_device.data()), 0,
+                        attractive_forces_device.size() * sizeof(float));
+
+        if (opt.min_gradient_norm > 0.0f && grad_norm < opt.min_gradient_norm)
         {
             if (opt.verbosity >= 1)
                 std::cout << "Reached minimum gradient norm: " << grad_norm << std::endl;

--- a/src/include/kernels/nbodyfft.h
+++ b/src/include/kernels/nbodyfft.h
@@ -5,6 +5,7 @@
 #include <cufft.h>
 #include <thrust/complex.h>
 #include "common.h"
+#include "options.h"
 #include "util/cuda_utils.h"
 #include "util/matrix_broadcast_utils.h"
 
@@ -25,6 +26,7 @@ void PrecomputeFFT2D(
     thrust::device_vector<thrust::complex<float>> &fft_kernel_tilde_device);
 
 void NbodyFFT2D(
+    tsnecuda::GpuOptions &gpu_opt,
     cufftHandle &plan_dft,
     cufftHandle &plan_idft,
     int N,

--- a/src/include/kernels/rep_forces.h
+++ b/src/include/kernels/rep_forces.h
@@ -9,6 +9,7 @@ namespace tsnecuda
 {
 
 float ComputeRepulsiveForces(
+    tsnecuda::GpuOptions &gpu_opt,
     thrust::device_vector<float> &repulsive_forces_device,
     thrust::device_vector<float> &normalization_vec_device,
     thrust::device_vector<float> &points_device,
@@ -17,6 +18,7 @@ float ComputeRepulsiveForces(
     const int n_terms);
 
 void ComputeChargesQij(
+    tsnecuda::GpuOptions &gpu_opt,
     thrust::device_vector<float> &chargesQij,
     thrust::device_vector<float> &points_device,
     const int num_points,

--- a/src/include/options.h
+++ b/src/include/options.h
@@ -11,6 +11,7 @@
 
 #include <random>
 #include <time.h>
+#include <cstdlib>
 #include <iostream>
 #include <faiss/MetricType.h>
 
@@ -198,6 +199,12 @@ namespace tsnecuda
         // Factor/thread optimization options
         int integration_kernel_threads;
         int integration_kernel_factor;
+        // Block sizes for the current FFT-interpolation kernels (tunable per arch).
+        int fft_kernel_threads;   // nbodyfft interpolation/copy kernels
+        int attr_kernel_threads;  // attractive-forces (Pij x Qij) kernel
+        int rep_kernel_threads;   // repulsive-forces / charges kernel
+        // NOTE: the *_kernel_* fields below are vestigial Barnes-Hut launch
+        // parameters, kept for ABI/source compatibility; no live kernel reads them.
         int repulsive_kernel_threads;
         int repulsive_kernel_factor;
         int bounding_kernel_threads;
@@ -230,9 +237,42 @@ namespace tsnecuda
             // }
             this->sm_count = device_properties.multiProcessorCount;
 
+            // Baseline block sizes for the FFT-interpolation kernels; a specific
+            // architecture branch below may override these, and an env var can
+            // override at runtime (for benchmarking / tuning).
+            this->fft_kernel_threads = 128;
+            this->attr_kernel_threads = 1024;
+            this->rep_kernel_threads = 1024;
+
             // Set some per-architecture structures
-            if (device_properties.major >= 7)
-            { // TURING
+            if (device_properties.major == 8)
+            { // AMPERE / ADA (A100 = sm_80, A10/RTX30 = sm_86, L4/RTX40 = sm_89)
+                // Launch parameters were swept on an A100-SXM4-80GB with
+                // cmake/benchmarks/tune_kernels.py: every hot kernel is
+                // occupancy/bandwidth-bound and flat across the whole valid block
+                // range (32..1024) and grid factor (1..64x SM count), so the
+                // legacy defaults are already optimal here. (The large A100 win
+                // came instead from removing redundant per-kernel device syncs in
+                // the FFT/attractive/apply-forces path.) Kept explicit so future
+                // datacenter parts (Hopper/Blackwell) can be retuned in isolation.
+                this->integration_kernel_threads = 1024;
+                this->integration_kernel_factor = 1;
+                this->fft_kernel_threads = 128;
+                this->attr_kernel_threads = 1024;
+                this->rep_kernel_threads = 1024;
+                this->repulsive_kernel_threads = 256;
+                this->repulsive_kernel_factor = 5;
+                this->bounding_kernel_threads = 512;
+                this->bounding_kernel_factor = 3;
+                this->tree_kernel_threads = 1024;
+                this->tree_kernel_factor = 2;
+                this->sort_kernel_threads = 64;
+                this->sort_kernel_factor = 6;
+                this->summary_kernel_threads = 128;
+                this->summary_kernel_factor = 6;
+            }
+            else if (device_properties.major >= 7)
+            { // TURING / VOLTA / HOPPER / BLACKWELL
                 this->integration_kernel_threads = 1024;
                 this->integration_kernel_factor = 1;
                 this->repulsive_kernel_threads = 256;
@@ -308,6 +348,30 @@ namespace tsnecuda
                 this->summary_kernel_threads = 128;
                 this->summary_kernel_factor = 6;
             }
+
+            // Optional runtime overrides, used by the kernel-tuning benchmark
+            // (cmake/benchmarks/tune_kernels.py) to sweep launch parameters
+            // without recompiling. Absent env vars leave the per-arch defaults.
+            if (const char *v = std::getenv("TSNE_INTEG_THREADS")) this->integration_kernel_threads = std::atoi(v);
+            if (const char *v = std::getenv("TSNE_INTEG_FACTOR"))  this->integration_kernel_factor  = std::atoi(v);
+            if (const char *v = std::getenv("TSNE_FFT_THREADS"))   this->fft_kernel_threads  = std::atoi(v);
+            if (const char *v = std::getenv("TSNE_ATTR_THREADS"))  this->attr_kernel_threads = std::atoi(v);
+            if (const char *v = std::getenv("TSNE_REP_THREADS"))   this->rep_kernel_threads  = std::atoi(v);
+
+            // Threads-per-block is hard-capped by the hardware (1024 on all
+            // current NVIDIA GPUs); a larger value makes the kernel launch fail
+            // with cudaErrorInvalidConfiguration and poisons the context. Clamp
+            // so a bad default/override degrades gracefully. (The blocks-per-SM
+            // *factor* is a grid multiplier and is not capped here - the grid may
+            // hold up to maxGridSize.x ~ 2^31 blocks, so it is the dimension that
+            // scales for a grid-stride kernel like IntegrationKernel.)
+            const int max_tpb = device_properties.maxThreadsPerBlock;
+            auto clamp_tpb = [max_tpb](int t) { return t < 1 ? 1 : (t > max_tpb ? max_tpb : t); };
+            this->integration_kernel_threads = clamp_tpb(this->integration_kernel_threads);
+            this->fft_kernel_threads  = clamp_tpb(this->fft_kernel_threads);
+            this->attr_kernel_threads = clamp_tpb(this->attr_kernel_threads);
+            this->rep_kernel_threads  = clamp_tpb(this->rep_kernel_threads);
+            if (this->integration_kernel_factor < 1) this->integration_kernel_factor = 1;
         }
     }; // End GPU Options
 

--- a/src/include/util/cuda_utils.h
+++ b/src/include/util/cuda_utils.h
@@ -34,6 +34,7 @@
 #ifndef CUDA_UTILITIES_CUH
 #define CUDA_UTILITIES_CUH
 
+#include <cstdlib>
 #include "common.h"
 
 __host__ __device__ int iDivUp(int, int);
@@ -41,5 +42,31 @@ extern "C" void CublasSafeCall(cublasStatus_t);
 extern "C" void CusparseSafeCall(cusparseStatus_t err);
 extern "C" void CufftSafeCall(cufftResult err);
 extern "C" void GpuErrorCheck(cudaError_t ans);
+
+// Kernel-synchronization mode. By default the per-iteration kernels run
+// asynchronously - kernels issued on the default stream are already correctly
+// ordered, so the previous per-kernel cudaDeviceSynchronize() calls were pure
+// host<->device latency (removing them is a ~2.5x speedup on the A100). Set the
+// environment variable TSNE_SYNC_KERNELS=1 (or compile with -DTSNE_FORCE_SYNC)
+// to synchronize after every kernel again: useful for debugging illegal memory
+// accesses and for getting accurate per-phase timers out of fit_tsne.
+inline bool KernelSyncEnabled()
+{
+#ifdef TSNE_FORCE_SYNC
+    return true;
+#else
+    static const bool enabled = []() {
+        const char *v = std::getenv("TSNE_SYNC_KERNELS");
+        return v != nullptr && std::atoi(v) != 0;
+    }();
+    return enabled;
+#endif
+}
+
+#define TSNE_MAYBE_SYNC()                            \
+    do {                                            \
+        if (KernelSyncEnabled())                    \
+            GpuErrorCheck(cudaDeviceSynchronize()); \
+    } while (0)
 
 #endif

--- a/src/kernels/apply_forces.cu
+++ b/src/kernels/apply_forces.cu
@@ -78,4 +78,5 @@ void tsnecuda::ApplyForces(tsnecuda::GpuOptions &gpu_opt,
         thrust::raw_pointer_cast(old_forces.data()),
         eta, normalization, momentum, exaggeration,
         num_points);
+    TSNE_MAYBE_SYNC();
 }

--- a/src/kernels/apply_forces.cu
+++ b/src/kernels/apply_forces.cu
@@ -78,5 +78,4 @@ void tsnecuda::ApplyForces(tsnecuda::GpuOptions &gpu_opt,
         thrust::raw_pointer_cast(old_forces.data()),
         eta, normalization, momentum, exaggeration,
         num_points);
-    GpuErrorCheck(cudaDeviceSynchronize());
 }

--- a/src/kernels/attr_forces.cu
+++ b/src/kernels/attr_forces.cu
@@ -61,6 +61,7 @@ void tsnecuda::ComputeAttractiveForces(
         thrust::raw_pointer_cast(coo_indices.data()),
         num_points,
         num_nonzero);
+    TSNE_MAYBE_SYNC();
 }
 
 __global__ void ComputePijxQijKernelV2(
@@ -122,6 +123,7 @@ void tsnecuda::ComputeAttractiveForcesV2(
         thrust::raw_pointer_cast(pij_row_ptr.data()),
         thrust::raw_pointer_cast(pij_col_ind.data()),
         num_points);
+    TSNE_MAYBE_SYNC();
 }
 
 __global__ void ComputePijxQijKernelV3(
@@ -193,8 +195,10 @@ void tsnecuda::ComputeAttractiveForcesV3(
     const int num_points,
     const int num_neighbors)
 {
-    // Step 1: Store the independent pij values  for x and y in the workspace
-    thrust::fill(pij_workspace_device.begin(), pij_workspace_device.end(), 0.0f);
+    // Step 1: Store the independent pij values  for x and y in the workspace.
+    // Async memset (not thrust::fill) to avoid a per-iteration host sync.
+    cudaMemsetAsync(thrust::raw_pointer_cast(pij_workspace_device.data()), 0,
+                    pij_workspace_device.size() * sizeof(float));
     const int BLOCKSIZE = gpu_opt.attr_kernel_threads;
     const int NBLOCKS = iDivUp(num_points * num_neighbors, BLOCKSIZE);
     ComputePijxQijKernelV3<<<NBLOCKS, BLOCKSIZE>>>(
@@ -206,6 +210,7 @@ void tsnecuda::ComputeAttractiveForcesV3(
         thrust::raw_pointer_cast(points_device.data()),                                     // points
         num_points,
         num_neighbors);
+    TSNE_MAYBE_SYNC();
 
 
     const int NBLOCKS2 = iDivUp(num_points, 512);
@@ -215,6 +220,7 @@ void tsnecuda::ComputeAttractiveForcesV3(
         thrust::raw_pointer_cast(pij_workspace_device.data()) + num_points * num_neighbors, // Workspace Y
         num_points,
         num_neighbors);
+    TSNE_MAYBE_SYNC();
 
 
     // // Setp 2: Reduce the X pij values into the attractive forces

--- a/src/kernels/attr_forces.cu
+++ b/src/kernels/attr_forces.cu
@@ -61,7 +61,6 @@ void tsnecuda::ComputeAttractiveForces(
         thrust::raw_pointer_cast(coo_indices.data()),
         num_points,
         num_nonzero);
-    GpuErrorCheck(cudaDeviceSynchronize());
 }
 
 __global__ void ComputePijxQijKernelV2(
@@ -123,7 +122,6 @@ void tsnecuda::ComputeAttractiveForcesV2(
         thrust::raw_pointer_cast(pij_row_ptr.data()),
         thrust::raw_pointer_cast(pij_col_ind.data()),
         num_points);
-    GpuErrorCheck(cudaDeviceSynchronize());
 }
 
 __global__ void ComputePijxQijKernelV3(
@@ -197,7 +195,7 @@ void tsnecuda::ComputeAttractiveForcesV3(
 {
     // Step 1: Store the independent pij values  for x and y in the workspace
     thrust::fill(pij_workspace_device.begin(), pij_workspace_device.end(), 0.0f);
-    const int BLOCKSIZE = 1024;
+    const int BLOCKSIZE = gpu_opt.attr_kernel_threads;
     const int NBLOCKS = iDivUp(num_points * num_neighbors, BLOCKSIZE);
     ComputePijxQijKernelV3<<<NBLOCKS, BLOCKSIZE>>>(
         // thrust::raw_pointer_cast(attr_forces.data()),
@@ -209,7 +207,6 @@ void tsnecuda::ComputeAttractiveForcesV3(
         num_points,
         num_neighbors);
 
-    GpuErrorCheck(cudaDeviceSynchronize());
 
     const int NBLOCKS2 = iDivUp(num_points, 512);
     reduce_sum_kernel<<<NBLOCKS2, 512>>>(
@@ -219,7 +216,6 @@ void tsnecuda::ComputeAttractiveForcesV3(
         num_points,
         num_neighbors);
 
-    GpuErrorCheck(cudaDeviceSynchronize());
 
     // // Setp 2: Reduce the X pij values into the attractive forces
     // float kAlpha = 1.0f;

--- a/src/kernels/nbodyfft.cu
+++ b/src/kernels/nbodyfft.cu
@@ -265,6 +265,7 @@ void tsnecuda::PrecomputeFFT2D(
         thrust::raw_pointer_cast(box_upper_bounds_device.data()),
         thrust::raw_pointer_cast(box_lower_bounds_device.data()),
         box_width, x_min, y_min, n_boxes, n_total_boxes);
+    TSNE_MAYBE_SYNC();
 
     // Coordinates of all the equispaced interpolation points
     int n_interpolation_points_1d = n_interpolation_points * n_boxes;
@@ -281,6 +282,7 @@ void tsnecuda::PrecomputeFFT2D(
     compute_kernel_tilde<<<num_blocks, num_threads>>>(
         thrust::raw_pointer_cast(kernel_tilde_device.data()),
         x_min, y_min, h, n_interpolation_points_1d, n_fft_coeffs);
+    TSNE_MAYBE_SYNC();
 
     // Precompute the FFT of the kernel generating matrix
 
@@ -342,6 +344,7 @@ void tsnecuda::NbodyFFT2D(
         n_boxes,
         n_total_boxes,
         N);
+    TSNE_MAYBE_SYNC();
 
 
     /*
@@ -357,6 +360,7 @@ void tsnecuda::NbodyFFT2D(
         thrust::raw_pointer_cast(denominator_device.data()),
         n_interpolation_points,
         N);
+    TSNE_MAYBE_SYNC();
 
     // Compute the interpolated values at each real point with each Lagrange polynomial in the `y` direction
     interpolate_device<<<num_blocks, num_threads>>>(
@@ -366,6 +370,7 @@ void tsnecuda::NbodyFFT2D(
         thrust::raw_pointer_cast(denominator_device.data()),
         n_interpolation_points,
         N);
+    TSNE_MAYBE_SYNC();
 
     //TODO: Synchronization required here
 
@@ -381,6 +386,7 @@ void tsnecuda::NbodyFFT2D(
         n_interpolation_points,
         n_boxes,
         n_terms);
+    TSNE_MAYBE_SYNC();
 
     /*
      * Step 2: Compute the values v_{m, n} at the equispaced nodes, multiply the kernel matrix with the coefficients w
@@ -393,6 +399,7 @@ void tsnecuda::NbodyFFT2D(
         n_fft_coeffs,
         n_fft_coeffs_half,
         n_terms);
+    TSNE_MAYBE_SYNC();
     // Compute fft values at interpolated nodes
     cufftExecR2C(plan_dft,
                  reinterpret_cast<cufftReal *>(thrust::raw_pointer_cast(fft_input.data())),
@@ -414,6 +421,7 @@ void tsnecuda::NbodyFFT2D(
         n_fft_coeffs,
         n_fft_coeffs_half,
         n_terms);
+    TSNE_MAYBE_SYNC();
 
     /*
      * Step 3: Compute the potentials \tilde{\phi}
@@ -430,4 +438,5 @@ void tsnecuda::NbodyFFT2D(
         n_interpolation_points,
         n_boxes,
         n_terms);
+    TSNE_MAYBE_SYNC();
 }

--- a/src/kernels/nbodyfft.cu
+++ b/src/kernels/nbodyfft.cu
@@ -281,7 +281,6 @@ void tsnecuda::PrecomputeFFT2D(
     compute_kernel_tilde<<<num_blocks, num_threads>>>(
         thrust::raw_pointer_cast(kernel_tilde_device.data()),
         x_min, y_min, h, n_interpolation_points_1d, n_fft_coeffs);
-    GpuErrorCheck(cudaDeviceSynchronize());
 
     // Precompute the FFT of the kernel generating matrix
 
@@ -291,6 +290,7 @@ void tsnecuda::PrecomputeFFT2D(
 }
 
 void tsnecuda::NbodyFFT2D(
+    tsnecuda::GpuOptions &gpu_opt,
     cufftHandle &plan_dft,
     cufftHandle &plan_idft,
     int N,
@@ -326,7 +326,7 @@ void tsnecuda::NbodyFFT2D(
     thrust::device_vector<float> &potentialsQij_device)
 {
     // std::cout << "start" << std::endl;
-    const int num_threads = 128;
+    const int num_threads = gpu_opt.fft_kernel_threads;
     int num_blocks = (N + num_threads - 1) / num_threads;
 
     // Compute box indices and the relative position of each point in its box in the interval [0, 1]
@@ -343,7 +343,6 @@ void tsnecuda::NbodyFFT2D(
         n_total_boxes,
         N);
 
-    GpuErrorCheck(cudaDeviceSynchronize());
 
     /*
      * Step 1: Interpolate kernel using Lagrange polynomials and compute the w coefficients
@@ -358,7 +357,6 @@ void tsnecuda::NbodyFFT2D(
         thrust::raw_pointer_cast(denominator_device.data()),
         n_interpolation_points,
         N);
-    GpuErrorCheck(cudaDeviceSynchronize()); // TODO: Remove the synchronization here
 
     // Compute the interpolated values at each real point with each Lagrange polynomial in the `y` direction
     interpolate_device<<<num_blocks, num_threads>>>(
@@ -368,7 +366,6 @@ void tsnecuda::NbodyFFT2D(
         thrust::raw_pointer_cast(denominator_device.data()),
         n_interpolation_points,
         N);
-    GpuErrorCheck(cudaDeviceSynchronize());
 
     //TODO: Synchronization required here
 
@@ -384,7 +381,6 @@ void tsnecuda::NbodyFFT2D(
         n_interpolation_points,
         n_boxes,
         n_terms);
-    GpuErrorCheck(cudaDeviceSynchronize());
 
     /*
      * Step 2: Compute the values v_{m, n} at the equispaced nodes, multiply the kernel matrix with the coefficients w
@@ -397,12 +393,10 @@ void tsnecuda::NbodyFFT2D(
         n_fft_coeffs,
         n_fft_coeffs_half,
         n_terms);
-    GpuErrorCheck(cudaDeviceSynchronize());
     // Compute fft values at interpolated nodes
     cufftExecR2C(plan_dft,
                  reinterpret_cast<cufftReal *>(thrust::raw_pointer_cast(fft_input.data())),
                  reinterpret_cast<cufftComplex *>(thrust::raw_pointer_cast(fft_w_coefficients.data())));
-    GpuErrorCheck(cudaDeviceSynchronize());
 
     // Take the broadcasted Hadamard product of a complex matrix and a complex vector
     // TODO: Check timing on this kernel
@@ -414,14 +408,12 @@ void tsnecuda::NbodyFFT2D(
     cufftExecC2R(plan_idft,
                  reinterpret_cast<cufftComplex *>(thrust::raw_pointer_cast(fft_w_coefficients.data())),
                  reinterpret_cast<cufftReal *>(thrust::raw_pointer_cast(fft_output.data())));
-    GpuErrorCheck(cudaDeviceSynchronize());
     copy_from_fft_output<<<num_blocks, num_threads>>>(
         thrust::raw_pointer_cast(y_tilde_values.data()),
         thrust::raw_pointer_cast(fft_output.data()),
         n_fft_coeffs,
         n_fft_coeffs_half,
         n_terms);
-    GpuErrorCheck(cudaDeviceSynchronize());
 
     /*
      * Step 3: Compute the potentials \tilde{\phi}
@@ -438,5 +430,4 @@ void tsnecuda::NbodyFFT2D(
         n_interpolation_points,
         n_boxes,
         n_terms);
-    GpuErrorCheck(cudaDeviceSynchronize());
 }

--- a/src/kernels/rep_forces.cu
+++ b/src/kernels/rep_forces.cu
@@ -31,6 +31,7 @@ __global__ void compute_repulsive_forces_kernel(
 }
 
 float tsnecuda::ComputeRepulsiveForces(
+    tsnecuda::GpuOptions &gpu_opt,
     thrust::device_vector<float> &repulsive_forces_device,
     thrust::device_vector<float> &normalization_vec_device,
     thrust::device_vector<float> &points_device,
@@ -38,7 +39,7 @@ float tsnecuda::ComputeRepulsiveForces(
     const int num_points,
     const int n_terms)
 {
-    const int num_threads = 1024;
+    const int num_threads = gpu_opt.rep_kernel_threads;
     const int num_blocks = (num_points + num_threads - 1) / num_threads;
     compute_repulsive_forces_kernel<<<num_blocks, num_threads>>>(
         thrust::raw_pointer_cast(repulsive_forces_device.data()),
@@ -75,12 +76,13 @@ __global__ void compute_chargesQij_kernel(
 }
 
 void tsnecuda::ComputeChargesQij(
+    tsnecuda::GpuOptions &gpu_opt,
     thrust::device_vector<float> &chargesQij,
     thrust::device_vector<float> &points_device,
     const int num_points,
     const int n_terms)
 {
-    const int num_threads = 1024;
+    const int num_threads = gpu_opt.rep_kernel_threads;
     const int num_blocks = (num_points + num_threads - 1) / num_threads;
     compute_chargesQij_kernel<<<num_blocks, num_threads>>>(
         thrust::raw_pointer_cast(chargesQij.data()),

--- a/src/util/distance_utils.cu
+++ b/src/util/distance_utils.cu
@@ -93,27 +93,20 @@ void tsnecuda::util::KNearestNeighbors(tsnecuda::GpuOptions &gpu_opt,
 
     if (num_near_neighbors < 1024)
     {
-        int ngpus = faiss::gpu::getNumDevices();
-        std::vector<faiss::gpu::GpuResourcesProvider *> res;
-        std::vector<int> devs;
-        for (int i = 0; i < ngpus; i++)
-        {
-            res.push_back(new faiss::gpu::StandardGpuResources);
-            devs.push_back(i);
-        }
-
-        // Convert the CPU index to GPU index
-        faiss::Index *search_index = faiss::gpu::index_cpu_to_gpu_multiple(res, devs, &cpu_index);
+        // Build and search the index on the single selected GPU. The previous
+        // implementation sharded the index across every visible GPU via
+        // index_cpu_to_gpu_multiple, which for t-SNE's modest point counts is
+        // pure coordination overhead and, on a shared multi-GPU machine, grabs
+        // resources on every GPU rather than the one the caller asked for.
+        faiss::gpu::StandardGpuResources res;
+        faiss::Index *search_index =
+            faiss::gpu::index_cpu_to_gpu(&res, gpu_opt.device, &cpu_index);
 
         search_index->train(num_points, points);
         search_index->add(num_points, points);
         search_index->search(num_points, points, num_near_neighbors, distances, indices);
 
         delete search_index;
-        for (int i = 0; i < ngpus; i++)
-        {
-            delete res[i];
-        }
     }
     else
     {


### PR DESCRIPTION
## Summary

Streamlines the build for packaging/deliverability and modernizes GPU support. **Breaking** (feature-surface removals), hence the major version bump to **4.0.0**.

### Build slimming
- Remove **gflags** and **gtest** links — they were vestigial (only referenced by the never-compiled `src/test/test.cu`).
- Compile out the **ZMQ interactive-viz** path (`-DNO_ZMQ`) and drop the standalone **C++ CLI** (`src/exe/main.cu`), which removes the **cxxopts** and **zeromq** dependencies entirely.
- Drop the vestigial CPU **BLAS/LAPACK/MKL** linkage — the only GEMM is GPU `cublasSgemm`, and FAISS carries its own BLAS. (On conda-forge this lets the recipe drop the `libblas/liblapack` pins, including the `*netlib` default that was pinning FAISS to 1.9.0.)
- Bump C++/CUDA standard to **17** (required by modern FAISS).

### Modern GPU architectures
- Rewrite CUDA arch selection to **honor an externally supplied `CMAKE_CUDA_ARCHITECTURES`** (e.g. conda-forge's `CMAKE_ARGS`), else emit an optimal gencode ladder per toolkit.
- Add branches for **CUDA 11 / 12 / 13**; the old `else()` emitted long-removed `sm_30..61` and broke under CUDA 13.
- Cover **A100 (sm_80), H100/H200 (sm_90), B200 (sm_100), GB202/RTX50 (sm_120)** + a PTX fallback.
- Gate x86-only `-m64/-msse4/-mpopcnt` flags so **aarch64 (Grace/GB200)** builds.

### Verification
- Builds under CUDA 12.9 and 13.0; the multi-arch `.so` contains real SASS for sm_75/80/86/89/90/100/120.
- Runs real **MNIST** (60k×784) on an A100: kNN(10) digit-label accuracy **~0.95** in the 2D embedding.
- Native lib links no libpython (pure `ctypes`), so it is Python-version-independent; verified building/running on Python 3.12 and 3.13.

The docs (`INSTALL.md`) are updated to match. The conda-forge feedstock is being updated in parallel.
