### PR TITLE
Fix CUDA 13 build (removed Thrust/cuFFT identifiers)

### DIFF
--- a/src/include/util/thrust_utils.h
+++ b/src/include/util/thrust_utils.h
@@ -24,8 +24,12 @@ template <typename Iterator>
 class StridedRange {
  public:
     typedef typename thrust::iterator_difference<Iterator>::type DifferenceType;
-    struct StrideFunctor :
-        public thrust::unary_function<DifferenceType, DifferenceType> {
+    // NB: thrust::unary_function was deprecated and removed in the Thrust that
+    // ships with CUDA 13, so we declare the typedefs it used to provide directly
+    // (still consumed by older Thrust's transform_iterator; harmless on newer).
+    struct StrideFunctor {
+        typedef DifferenceType argument_type;
+        typedef DifferenceType result_type;
         DifferenceType stride;
         explicit StrideFunctor(DifferenceType stride)
             : stride(stride) {}

--- a/src/util/cuda_utils.cu
+++ b/src/util/cuda_utils.cu
@@ -200,11 +200,17 @@ static const char *_cufftGetErrorEnum(cufftResult error)
         case CUFFT_INVALID_DEVICE:
             return "CUFFT_INVALID_DEVICE";
 
+#if CUDART_VERSION < 13000
+        // Removed from the cuFFT result enum in CUDA 13.
         case CUFFT_INCOMPLETE_PARAMETER_LIST:
             return "CUFFT_INCOMPLETE_PARAMETER_LIST";
+#endif
 
+#if CUDART_VERSION < 13000
+        // Removed from the cuFFT result enum in CUDA 13.
         case CUFFT_PARSE_ERROR:
             return "CUFFT_PARSE_ERROR";
+#endif
 
         case CUFFT_NO_WORKSPACE:
             return "CUFFT_NO_WORKSPACE";
@@ -215,8 +221,11 @@ static const char *_cufftGetErrorEnum(cufftResult error)
         case CUFFT_NOT_IMPLEMENTED:
             return "CUFFT_NOT_IMPLEMENTED";
 
+#if CUDART_VERSION < 13000
+        // Removed from the cuFFT result enum in CUDA 13.
         case CUFFT_LICENSE_ERROR:
             return "CUFFT_LICENSE_ERROR";
+#endif
 
         default:
             return "<unknown>";


### PR DESCRIPTION
CUDA 13 ships a newer Thrust and cuFFT that removed several long-deprecated identifiers the code still referenced, so tsne-cuda did not actually compile under CUDA 13 (the 4.0.0 arch ladder was exercised, but only with a trivial kernel).

- `thrust::unary_function` was removed → declare the `argument_type`/`result_type` typedefs on `StrideFunctor` directly (older Thrust still consumes them; harmless on newer).
- The cuFFT result enum dropped `CUFFT_PARSE_ERROR`, `CUFFT_LICENSE_ERROR`, and `CUFFT_INCOMPLETE_PARAMETER_LIST` → guard those `switch` cases with `#if CUDART_VERSION < 13000`.

Verified the full source compiles under CUDA 13.0, and a CUDA-13 wheel (built via the modernized packaging pipeline, FAISS 1.11) runs MNIST (60k, 1000 iters) on an A100 with kNN accuracy 0.955. The `tsnecuda-4.0.0+cu130` wheel on the v4.0.0 release is built from this fix.
